### PR TITLE
Add option to use ec2 instance-id as sensu client name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'phil@hellmi.de'
 license 'Apache-2.0'
 description 'A cookbook for monitoring services, using Sensu, a monitoring framework.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.11'
+version '0.9.12'
 chef_version '~> 12'
 
 issues_url 'https://github.com/runningman84/chef-monitor/issues'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -55,6 +55,10 @@ client_attributes['influxdb']['tags'] ||= {}
 client_name = node.name
 
 if node.key?('ec2') && node['ec2'].is_a?(Hash)
+  if node['sensu']['instance_id_name_override'] == true
+    client_name = node['ec2']['instance_id']
+    Chef::Log.warn("Overridding sensu client name to be #{client_name}")
+  end
   client_subscriptions << 'aws:ec2'
   client_attributes['ec2'] = {}
   %w(


### PR DESCRIPTION
When applicable , add option to use ec2 instance-id as sensu client name instead of chef node name, 